### PR TITLE
Improve RISC-V startup templates

### DIFF
--- a/share/startup-gen/resources/riscv.S.tmplt
+++ b/share/startup-gen/resources/riscv.S.tmplt
@@ -25,6 +25,16 @@ _start:
 .option pop
         la sp, __stack_end
 
+@@--
+@@--  This part of the template implements an infinite loop for all core with
+@@--  an ID different than the one provided.
+@@--
+@@IF@@ @_EXIST:only_allow_hart_id_@
+        li   t0, @_only_allow_hart_id_@ /* hart id that will be allowed to run */
+        csrr t1, mhartid
+1:      bne t0, t1, 1b
+@@END_IF@@
+
 @@IF@@ @_BOOT_FROM_ROM_@
         /* Load data section */
         .type _startup_copy_data,@function
@@ -90,6 +100,12 @@ _startup_clear_@_RAM_REGION_@_bss:
         .size _startup_clear_@_RAM_REGION_@_bss, . - _startup_clear_@_RAM_REGION_@_bss
 
 @@END_TABLE@@
+
+@@IF@@ @_VAR1_@ = "HARD"
+        /* Enable the FPU */
+        li      t0, 0x00006000
+        csrs    mstatus, t0
+@@END_IF@@
 
         /* Call static constructors */
 .weak __libc_init_array

--- a/src/device.adb
+++ b/src/device.adb
@@ -630,7 +630,9 @@ package body Device is
       end loop;
 
       return User_Assocs &
-             (Templates_Parser.Assoc ("BOOT_FROM_ROM", Self.Boot_From_ROM),
+              (Templates_Parser.Assoc ("FLOAT_HANDLING",
+                                       Self.CPU.Float_Handling'Img),
+              Templates_Parser.Assoc ("BOOT_FROM_ROM", Self.Boot_From_ROM),
               Templates_Parser.Assoc ("BOOT_MEM", Boot_Mem),
               Templates_Parser.Assoc ("BOOT_MEM_ADDR", Boot_Mem_Addr),
               Templates_Parser.Assoc ("BOOT_MEM_SIZE", Boot_Mem_Size),

--- a/testsuite/tests/boards/polarfiresoc/prj.gpr
+++ b/testsuite/tests/boards/polarfiresoc/prj.gpr
@@ -29,6 +29,7 @@ project Prj is
 
       for User_Tag ("polarfire_lsr_root") use "0x20000000";
       for User_Tag ("qemu_sifive_test_exit") use "True";
+      for User_Tag ("only_allow_hart_id") use "1";
    end Device_Configuration;
 
 end Prj;

--- a/testsuite/tests/boards/polarfiresoc/test.py
+++ b/testsuite/tests/boards/polarfiresoc/test.py
@@ -2,27 +2,6 @@ from testsuite_support.utils import run_tool, gprbuild, runcross, contents_of
 
 run_tool(['-P', 'prj.gpr', '-s', 'src/crt0.S', '-l', 'src/linker.ld'])
 
-
-def add_hard_busy_loop(filename):
-    f = open(filename, "r")
-    contents = f.readlines()
-    f.close()
-
-    for index in range(len(contents)):
-        if "__stack_end" in contents[index]:
-            # Insert a piece of code that will only allow hart 1 to continue
-            contents.insert(index + 1, "        li   t0, 1\n")
-            contents.insert(index + 2, "1:      csrr t1, mhartid\n")
-            contents.insert(index + 3, "        bne t0, t1, 1b\n")
-            break
-    f = open(filename, "w")
-    contents = "".join(contents)
-    f.write(contents)
-    f.close()
-
-
-add_hard_busy_loop("src/crt0.S")
-
 gprbuild(['-f', '-P', 'prj.gpr'])
 
 runcross('riscv64-elf', 'qemu-polarfiresoc', 'obj/main', output='runcross.out')

--- a/testsuite/tests/templates/print_tags/test.ref
+++ b/testsuite/tests/templates/print_tags/test.ref
@@ -1,4 +1,5 @@
 --- Template tags ---
+FLOAT_HANDLING => SOFT
 BOOT_FROM_ROM => TRUE
 BOOT_MEM => ("rom2")
 BOOT_MEM_ADDR => ("0x20")

--- a/testsuite/tests/templates/user_tags/test.ref
+++ b/testsuite/tests/templates/user_tags/test.ref
@@ -1,6 +1,7 @@
 --- Template tags ---
 test_user_tag_1 => 42
 test_user_tag_2 => 42
+FLOAT_HANDLING => SOFT
 BOOT_FROM_ROM => TRUE
 BOOT_MEM => ("rom1")
 BOOT_MEM_ADDR => ("0x10")


### PR DESCRIPTION
 - To enable the FPU when hardware float is specified
 - To give to option to run on a single core/hart

Part of U127-004.