### PR TITLE
riscv: use the MSS_RESET_CR register to reset the board

### DIFF
--- a/share/startup-gen/resources/riscv.S.tmplt
+++ b/share/startup-gen/resources/riscv.S.tmplt
@@ -150,10 +150,10 @@ _startup_clear_@_RAM_REGION_@_bss:
         .type abort,@function
 abort:
 __gnat_exit:
-        /* Write to the SiFive Test device on QEMU to shutdown */
-        li t0, 0x5555
-        li t1, 0x100000
-        sw t0, (t1)
+        /* Write 0xDEAD to MSS_RESET_CR.  */
+        li t0, 0x20002018
+        li t1, 0xDEAD
+        sw t1, (t0)
 
         j __gnat_exit
 

--- a/testsuite/tests/boards/polarfiresoc/src/main.adb
+++ b/testsuite/tests/boards/polarfiresoc/src/main.adb
@@ -8,8 +8,8 @@ with Test;
 
 procedure Main is
 
-   Test_Device : Unsigned_32
-     with Address => System'To_Address (16#100000#);
+   Mss_Reset_Cr : Unsigned_32
+     with Address => System'To_Address (16#20002018#);
 
 begin
    Put_Line ("=== Test for RISC-V64 PolarFire SOC ===");
@@ -21,6 +21,6 @@ begin
 
    Test.Check_Memories;
 
-   Test_Device := 16#5555#;
+   Mss_Reset_Cr := 16#DEAD#;
 
 end Main;


### PR DESCRIPTION
This is required to make the Polarfire board reset to work.

TN: U716-025