### PR TITLE
RISC-V32: fix reset on QEMU

### DIFF
--- a/share/startup-gen/resources/riscv.S.tmplt
+++ b/share/startup-gen/resources/riscv.S.tmplt
@@ -139,10 +139,34 @@ _startup_clear_@_RAM_REGION_@_bss:
 
 @@--
 @@--  This part of the template implements an optional exit function for
-@@--  the polarfire SOC and HiFive1 emulation on QEMU. This is included for
-@@--  testing purposes.
+@@--  the HiFive1 emulation on QEMU. This is included for testing purposes.
 @@--
 @@IF@@ @_EXIST:qemu_sifive_test_exit_@
+
+        .globl __gnat_exit
+        .type __gnat_exit,@function
+        .globl _abort
+        .type abort,@function
+abort:
+__gnat_exit:
+        /* Write to the SiFive Test device on QEMU to shutdown */
+        li t0, 0x5555
+        li t1, 0x100000
+        sw t0, (t1)
+
+        j __gnat_exit
+
+        /* Weak alias _exit to __gnat_exit */
+        .weak      _exit
+        .set _exit,__gnat_exit
+@@END_IF@@
+
+@@--
+@@--  This part of the template implements an optional exit function for
+@@--  the polarfire SOC emulation on QEMU. This is included for testing
+@@--  purposes.
+@@--
+@@IF@@ @_EXIST:qemu_polarfire_test_exit_@
 
         .globl __gnat_exit
         .type __gnat_exit,@function

--- a/testsuite/tests/boards/polarfiresoc/prj.gpr
+++ b/testsuite/tests/boards/polarfiresoc/prj.gpr
@@ -28,7 +28,7 @@ project Prj is
       for Size ("ram")     use "128M";
 
       for User_Tag ("polarfire_lsr_root") use "0x20000000";
-      for User_Tag ("qemu_sifive_test_exit") use "True";
+      for User_Tag ("qemu_polarfire_test_exit") use "True";
       for User_Tag ("only_allow_hart_id") use "1";
    end Device_Configuration;
 

--- a/testsuite/tests/boards/polarfiresoc/src/main.adb
+++ b/testsuite/tests/boards/polarfiresoc/src/main.adb
@@ -7,10 +7,6 @@ with Ada.Text_IO; use Ada.Text_IO;
 with Test;
 
 procedure Main is
-
-   Mss_Reset_Cr : Unsigned_32
-     with Address => System'To_Address (16#20002018#);
-
 begin
    Put_Line ("=== Test for RISC-V64 PolarFire SOC ===");
 
@@ -20,7 +16,4 @@ begin
         Volatile => True);
 
    Test.Check_Memories;
-
-   Mss_Reset_Cr := 16#DEAD#;
-
 end Main;


### PR DESCRIPTION
The previous patch fixed polarfire but broke Hifive1. This patch
introduces a separate __gnat_exit for the polarfire.

Part of V127-041.